### PR TITLE
Feature/bot cat off

### DIFF
--- a/server/apps/bot/services/country.py
+++ b/server/apps/bot/services/country.py
@@ -46,7 +46,7 @@ def create_settings(chn: Channel):
             if not ChannelIncidentType.objects.filter(
                 channel=chn, incident_type=it
             ).exists():
-                cit = ChannelIncidentType(channel=chn, incident_type=it, status=True)
+                cit = ChannelIncidentType(channel=chn, incident_type=it, status=False)
                 channel_incident_types.append(cit)
                 for c in Country.objects.all():
                     if not ChannelCountry.objects.filter(


### PR DESCRIPTION
При создании настроек для канала 
- когда бот добавляется в канал
- когда дообавляется новый инцидент
- или напрямую вызывается этот процесс при помощи комманды

Теперь все категории будут выключены и для получения оповещений их надо будет явно включать руками