### PR TITLE
Feature/ci split test envs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,11 @@ on:
         options:
           - Force build
           - Default
+      keepTests:
+        description: "Keep test artifacts and folders. They will automatically be kept in case of failed tests"
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   clean:
@@ -41,6 +46,8 @@ jobs:
       - build
     uses: "./.github/workflows/tests.web.yml"
     secrets: inherit
+    with:
+      keepTests: "${{ github.event.inputs.keepTests }}"
 
   start_staging:
     name: Start staging

--- a/.github/workflows/tests.web.yml
+++ b/.github/workflows/tests.web.yml
@@ -70,6 +70,7 @@ jobs:
 
           # NOTICE: running dev version of docker-compose.yaml on purpose, to not mistakingly do anything production-like.
           docker compose -f docker-compose.yaml run \
+              --build \
               --rm \
               -e COVERAGE_FILE=${TEST_REPORT_ROOT}/coverage.db \
               -u $UID \

--- a/.github/workflows/tests.web.yml
+++ b/.github/workflows/tests.web.yml
@@ -4,6 +4,12 @@ name: Web tests
 
 on:
   workflow_call:
+    inputs:
+      # force keeping tests regardless of the outcome
+      keepTests:
+        type: boolean
+        default: false
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -117,7 +123,7 @@ jobs:
           fi
       
       - name: Cleanup tests
-        if: always()
+        if: inputs.keepTests || success()
         run: |
           echo "Cleaning up test dir: ${TEST_DIR}"
           rm -rf ${TEST_DIR};


### PR DESCRIPTION
## Changes

- Tests are NOT cleaned up if failed. Useful for reproducing issues or debugging;

## Fixes

- New CI variable to keep tests even after a successful run;
- Test images are being built regardless if they are cached or not;
